### PR TITLE
RAIN-1586(Common Pay :: Arrears tax heads should not be displayed in the common pay screen if Arrears are not available for the modules.)

### DIFF
--- a/web/rainmaker/dev-packages/egov-common-dev/src/ui-molecules-local/FeesEstimateCard/index.js
+++ b/web/rainmaker/dev-packages/egov-common-dev/src/ui-molecules-local/FeesEstimateCard/index.js
@@ -83,7 +83,7 @@ function FeesEstimateCard(props) {
   const arrears = estimate.arrears;
   const totalHeadClassName = "tl-total-amount-value " + classes.bigheader;
 
-  if (estimate.fees&&estimate.fees.length>0&&estimate.fees[estimate.fees.length-1].info.labelName!="Arrears") {
+  if (estimate.fees&&estimate.fees.length>0&&estimate.fees[estimate.fees.length-1].info.labelName!="Arrears" && parseInt(arrears)> 0 ) {
     estimate.fees.push({
       info: {
         labelKey: "COMMON_ARREARS",


### PR DESCRIPTION
RAIN-1586(Common Pay :: Arrears tax heads should not be displayed in the common pay screen if Arrears are not available for the modules.)